### PR TITLE
Avoid warning when getting terminal size

### DIFF
--- a/TreeDumper.pm
+++ b/TreeDumper.pm
@@ -763,7 +763,7 @@ else
 		}
 	else
 		{
-		my ($columns, $rows) = ('', '') ;
+		my $columns = '' ;
 		
 		if(defined $setup->{WRAP_WIDTH})
 			{
@@ -775,15 +775,15 @@ else
 				{
 				if($^O ne 'MSWin32')
 					{
-					eval "(\$columns, \$rows) = Term::Size::chars *STDOUT{IO} ;" ;
+					eval '$columns = Term::Size::chars *STDOUT{IO} ;' ;
 					}
 				else
 					{
-					($columns, $rows) = $WIN32_CONSOLE->Size();
+					($columns) = $WIN32_CONSOLE->Size();
 					}
 				}
 				
-			if($columns eq '')
+			unless($columns)
 				{
 				$columns = $setup->{VIRTUAL_WIDTH}  ;
 				}


### PR DESCRIPTION
Would you please consider this change to Data::TreeDumper?

Slaven Rezić found that the warnings provoke the failure of 'no warning' tests on Data::TreeDumper::Utils (see [CPAN RT#127670](https://rt.cpan.org/Public/Bug/Display.html?id=127670)).

_____

Latest versions of Term::Size introduced a bug fix where

    Term::Size::chars()

returns on error an empty list on list context and undef on scalar context.

This change reconciliates the code to both old and new Term::Size
versions by using Term::Size::chars() in scalar context and testing
$columns for falseness (rather than by equality to '').